### PR TITLE
fix: resolve React hydration mismatch by disabling SSR for MainContent

### DIFF
--- a/src/app/[projectId]/page.tsx
+++ b/src/app/[projectId]/page.tsx
@@ -1,7 +1,12 @@
+import dynamic from "next/dynamic";
 import { getUser } from "@/actions";
 import { getProject } from "@/actions/get-project";
-import { MainContent } from "@/app/main-content";
 import { redirect } from "next/navigation";
+
+const MainContent = dynamic(
+  () => import("@/app/main-content").then((m) => ({ default: m.MainContent })),
+  { ssr: false }
+);
 
 interface PageProps {
   params: Promise<{ projectId: string }>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,13 @@
+import dynamic from "next/dynamic";
 import { getUser } from "@/actions";
 import { getProjects } from "@/actions/get-projects";
 import { createProject } from "@/actions/create-project";
-import { MainContent } from "./main-content";
 import { redirect } from "next/navigation";
+
+const MainContent = dynamic(
+  () => import("./main-content").then((m) => ({ default: m.MainContent })),
+  { ssr: false }
+);
 
 export default async function Home() {
   const user = await getUser();


### PR DESCRIPTION
Fixes #5

## Summary

- Both `react-resizable-panels` and `@radix-ui/react-tabs` use `useId()` internally, generating element IDs that differ between SSR and client hydration
- Replaced static `MainContent` imports in both page files with `next/dynamic` + `{ ssr: false }`
- `MainContent` is fully client-interactive with no SEO requirements, so skipping SSR is appropriate

Generated with [Claude Code](https://claude.ai/code)